### PR TITLE
Bump package versions and update code for compiler 0.12

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: node_js
 dist: trusty
 sudo: required
-node_js: 6
+node_js: stable
 install:
   - npm install -g bower
   - npm install

--- a/bower.json
+++ b/bower.json
@@ -20,6 +20,7 @@
     "package.json"
   ],
   "dependencies": {
-    "purescript-strongcheck": "^3.0.0"
+    "purescript-strongcheck": "^4.0.0",
+    "purescript-proxy": "^3.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -6,9 +6,9 @@
     "test": "pulp test"
   },
   "devDependencies": {
-    "pulp": "^11.0.0",
-    "purescript-psa": "^0.5.0",
-    "purescript": "^0.11.1",
-    "rimraf": "^2.6.1"
+    "pulp": "^12.3.0",
+    "purescript-psa": "^0.6.0",
+    "purescript": "^0.12.0",
+    "rimraf": "^2.6.2"
   }
 }

--- a/src/Test/StrongCheck/Laws.purs
+++ b/src/Test/StrongCheck/Laws.purs
@@ -1,18 +1,15 @@
 module Test.StrongCheck.Laws
   ( module Test.StrongCheck.Laws
-  , module Test.StrongCheck
   ) where
 
 import Prelude
 
-import Control.Monad.Eff.Console (log)
+import Effect.Console (log)
 
-import Data.Monoid (class Monoid)
-
-import Test.StrongCheck (SC)
+import Effect (Effect)
 import Test.StrongCheck.Arbitrary (class Arbitrary, arbitrary, class Coarbitrary, coarbitrary)
 
-checkLaws ∷ ∀ eff. String → SC eff Unit → SC eff Unit
+checkLaws ∷ String → Effect Unit → Effect Unit
 checkLaws typeName laws = do
   log $ "\n\nChecking laws of " <> typeName <> " instances...\n"
   laws

--- a/src/Test/StrongCheck/Laws/Control/Alt.purs
+++ b/src/Test/StrongCheck/Laws/Control/Alt.purs
@@ -3,21 +3,21 @@ module Test.StrongCheck.Laws.Control.Alt where
 import Prelude
 
 import Control.Alt (class Alt, (<|>))
-import Control.Monad.Eff.Console (log)
-
-import Type.Proxy (Proxy2)
-
-import Test.StrongCheck (SC, quickCheck')
+import Effect (Effect)
+import Effect.Console (log)
+import Test.StrongCheck (quickCheck')
 import Test.StrongCheck.Arbitrary (class Arbitrary)
 import Test.StrongCheck.Laws (A, B)
+import Type.Proxy (Proxy2)
 
 -- | - Associativity: `(x <|> y) <|> z == x <|> (y <|> z)`
 -- | - Distributivity: `f <$> (x <|> y) == (f <$> x) <|> (f <$> y)`
 checkAlt
-  ∷ ∀ eff f
-  . Alt f ⇒ Arbitrary (f A) ⇒ Eq (f A) ⇒ Eq (f B)
+  ∷ ∀ f
+  . Alt f
+  ⇒ Arbitrary (f A) ⇒ Eq (f A) ⇒ Eq (f B)
   ⇒ Proxy2 f
-  → SC eff Unit
+  → Effect Unit
 checkAlt _ = do
 
   log "Checking 'Associativity' law for Alt"

--- a/src/Test/StrongCheck/Laws/Control/Alternative.purs
+++ b/src/Test/StrongCheck/Laws/Control/Alternative.purs
@@ -4,22 +4,21 @@ import Prelude
 
 import Control.Alt ((<|>))
 import Control.Alternative (class Alternative)
-import Control.Monad.Eff.Console (log)
 import Control.Plus (empty)
-
-import Type.Proxy (Proxy2)
-
-import Test.StrongCheck (SC, quickCheck')
+import Effect (Effect)
+import Effect.Console (log)
+import Test.StrongCheck (quickCheck')
 import Test.StrongCheck.Arbitrary (class Arbitrary)
 import Test.StrongCheck.Laws (A, B)
+import Type.Proxy (Proxy2)
 
 -- | - Distributivity: `(f <|> g) <*> x == (f <*> x) <|> (g <*> x)`
 -- | - Annihilation: `empty <*> x = empty`
 checkAlternative
-  ∷ ∀ eff f
+  ∷ ∀ f
   . Alternative f ⇒ Arbitrary (f (A → B)) ⇒ Arbitrary (f A) ⇒ Eq (f A) ⇒ Eq (f B)
   ⇒ Proxy2 f
-  → SC eff Unit
+  → Effect Unit
 checkAlternative _ = do
 
   log "Checking 'Left identity' law for Alternative"
@@ -34,4 +33,4 @@ checkAlternative _ = do
   distributivity f g x = ((f <|> g) <*> x) == ((f <*> x) <|> (g <*> x))
 
   annihilation ∷ f A → Boolean
-  annihilation x = empty <*> x == empty ∷ f A
+  annihilation x = (empty <*> x) == empty ∷ f A

--- a/src/Test/StrongCheck/Laws/Control/Applicative.purs
+++ b/src/Test/StrongCheck/Laws/Control/Applicative.purs
@@ -2,27 +2,32 @@ module Test.StrongCheck.Laws.Control.Applicative where
 
 import Prelude
 
-import Control.Monad.Eff.Console (log)
-
-import Type.Proxy (Proxy2)
-
-import Test.StrongCheck (SC, quickCheck')
+import Effect (Effect)
+import Effect.Console (log)
+import Test.StrongCheck (quickCheck')
 import Test.StrongCheck.Arbitrary (class Arbitrary)
 import Test.StrongCheck.Laws (A, B, C)
+import Type.Proxy (Proxy2)
 
 -- | - Identity: `(pure id) <*> v = v`
 -- | - Composition: `(pure (<<<)) <*> f <*> g <*> h = f <*> (g <*> h)`
 -- | - Homomorphism: `(pure f) <*> (pure x) = pure (f x)`
 -- | - Interchange: `u <*> (pure y) = (pure ($ y)) <*> u`
 checkApplicative
-  ∷ ∀ eff f
-  . Applicative f ⇒ Arbitrary (f A) ⇒ Arbitrary (f (A → B)) ⇒ Arbitrary (f (B → C)) ⇒ Eq (f A) ⇒ Eq (f B) ⇒ Eq (f C)
+  ∷ ∀ f
+  . Applicative f
+  ⇒ Arbitrary (f A)
+  ⇒ Arbitrary (f (A → B))
+  ⇒ Arbitrary (f (B → C))
+  ⇒ Eq (f A)
+  ⇒ Eq (f B)
+  ⇒ Eq (f C)
   ⇒ Proxy2 f
-  → SC eff Unit
+  → Effect Unit
 checkApplicative _ = do
 
   log "Checking 'Identity' law for Applicative"
-  quickCheck' 1000 identity
+  quickCheck' 1000 identity'
 
   log "Checking 'Composition' law for Applicative"
   quickCheck' 1000 composition
@@ -35,8 +40,8 @@ checkApplicative _ = do
 
   where
 
-  identity ∷ f A → Boolean
-  identity v = (pure id <*> v) == v
+  identity' ∷ f A → Boolean
+  identity' v = (pure identity <*> v) == v
 
   composition ∷ f (B → C) → f (A → B) → f A → Boolean
   composition f g x = (pure (<<<) <*> f <*> g <*> x) == (f <*> (g <*> x))

--- a/src/Test/StrongCheck/Laws/Control/Apply.purs
+++ b/src/Test/StrongCheck/Laws/Control/Apply.purs
@@ -2,20 +2,23 @@ module Test.StrongCheck.Laws.Control.Apply where
 
 import Prelude
 
-import Control.Monad.Eff.Console (log)
-
-import Type.Proxy (Proxy2)
-
-import Test.StrongCheck (SC, quickCheck')
+import Effect (Effect)
+import Effect.Console (log)
+import Test.StrongCheck (quickCheck')
 import Test.StrongCheck.Arbitrary (class Arbitrary)
 import Test.StrongCheck.Laws (A, B, C)
+import Type.Proxy (Proxy2)
 
 -- | - Associative composition: `(<<<) <$> f <*> g <*> h = f <*> (g <*> h)`
 checkApply
-  ∷ ∀ eff f
-  . Apply f ⇒ Arbitrary (f A) ⇒ Arbitrary (f (A → B)) ⇒ Arbitrary (f (B → C)) ⇒ Eq (f C)
+  ∷ ∀ f
+  . Apply f
+  ⇒ Arbitrary (f A)
+  ⇒ Arbitrary (f (A → B))
+  ⇒ Arbitrary (f (B → C))
+  ⇒ Eq (f C)
   ⇒ Proxy2 f
-  → SC eff Unit
+  → Effect Unit
 checkApply _ = do
 
   log "Checking 'Associative composition' law for Apply"

--- a/src/Test/StrongCheck/Laws/Control/Bind.purs
+++ b/src/Test/StrongCheck/Laws/Control/Bind.purs
@@ -2,20 +2,21 @@ module Test.StrongCheck.Laws.Control.Bind where
 
 import Prelude
 
-import Control.Monad.Eff.Console (log)
-
-import Type.Proxy (Proxy2)
-
-import Test.StrongCheck (SC, quickCheck')
+import Effect (Effect)
+import Effect.Console (log)
+import Test.StrongCheck (quickCheck')
 import Test.StrongCheck.Arbitrary (class Arbitrary)
 import Test.StrongCheck.Laws (A)
+import Type.Proxy (Proxy2)
 
 -- | - Associativity: `(x >>= f) >>= g = x >>= (\k → f k >>= g)`
 checkBind
-  ∷ ∀ eff m
-  . Bind m ⇒ Arbitrary (m A) ⇒ Eq (m A)
+  ∷ ∀ m
+  . Bind m
+  ⇒ Arbitrary (m A)
+  ⇒ Eq (m A)
   ⇒ Proxy2 m
-  → SC eff Unit
+  → Effect Unit
 checkBind _ = do
 
   log "Checking 'Associativity' law for Bind"

--- a/src/Test/StrongCheck/Laws/Control/Category.purs
+++ b/src/Test/StrongCheck/Laws/Control/Category.purs
@@ -2,27 +2,28 @@ module Test.StrongCheck.Laws.Control.Category where
 
 import Prelude
 
-import Control.Monad.Eff.Console (log)
-
-import Type.Proxy (Proxy3)
-
-import Test.StrongCheck (SC, quickCheck')
+import Effect (Effect)
+import Effect.Console (log)
+import Test.StrongCheck (quickCheck')
 import Test.StrongCheck.Arbitrary (class Arbitrary)
 import Test.StrongCheck.Laws (B, C)
+import Type.Proxy (Proxy3)
 
 -- | - Identity: `id <<< p = p <<< id = p`
 checkCategory
-  ∷ ∀ eff a
-  . Category a ⇒ Arbitrary (a B C) ⇒ Eq (a B C)
+  ∷ ∀ a
+  . Category a
+  ⇒ Arbitrary (a B C)
+  ⇒ Eq (a B C)
   ⇒ Proxy3 a
-  → SC eff Unit
+  → Effect Unit
 checkCategory _ = do
 
   log "Checking 'Identity' law for Category"
-  quickCheck' 1000 identity
+  quickCheck' 1000 identity'
 
   where
 
-  identity ∷ a B C → Boolean
-  identity p = (id <<< p) == p
-            && (p <<< id) == p
+  identity' ∷ a B C → Boolean
+  identity' p = (identity <<< p) == p
+            && (p <<< identity) == p

--- a/src/Test/StrongCheck/Laws/Control/Comonad.purs
+++ b/src/Test/StrongCheck/Laws/Control/Comonad.purs
@@ -2,23 +2,25 @@ module Test.StrongCheck.Laws.Control.Comonad where
 
 import Prelude
 
-import Control.Monad.Eff.Console (log)
 import Control.Comonad (class Comonad, extract)
 import Control.Extend ((<<=))
-
-import Type.Proxy (Proxy2)
-
-import Test.StrongCheck (SC, quickCheck')
+import Effect (Effect)
+import Effect.Console (log)
+import Test.StrongCheck (quickCheck')
 import Test.StrongCheck.Arbitrary (class Arbitrary, class Coarbitrary)
 import Test.StrongCheck.Laws (A, B)
+import Type.Proxy (Proxy2)
 
 -- | - Left Identity: `extract <<= x = x`
 -- | - Right Identity: `extract (f <<= x) = f x`
 checkComonad
-  ∷ ∀ eff w
-  . Comonad w ⇒ Arbitrary (w A) ⇒ Coarbitrary (w A) ⇒ Eq (w A)
+  ∷ ∀ w
+  . Comonad w
+  ⇒ Arbitrary (w A)
+  ⇒ Coarbitrary (w A)
+  ⇒ Eq (w A)
   ⇒ Proxy2 w
-  → SC eff Unit
+  → Effect Unit
 checkComonad _ = do
 
   log "Checking 'Left identity' law for Comonad"

--- a/src/Test/StrongCheck/Laws/Control/Extend.purs
+++ b/src/Test/StrongCheck/Laws/Control/Extend.purs
@@ -3,20 +3,23 @@ module Test.StrongCheck.Laws.Control.Extend where
 import Prelude
 
 import Control.Extend (class Extend, (<<=))
-import Control.Monad.Eff.Console (log)
-
-import Type.Proxy (Proxy2)
-
-import Test.StrongCheck (SC, quickCheck')
+import Effect (Effect)
+import Effect.Console (log)
+import Test.StrongCheck (quickCheck')
 import Test.StrongCheck.Arbitrary (class Arbitrary, class Coarbitrary)
 import Test.StrongCheck.Laws (A, B, C)
+import Type.Proxy (Proxy2)
 
 -- | - Associativity: `extend f <<< extend g = extend (f <<< extend g)`
 checkExtend
-  ∷ ∀ eff w
-  . Extend w ⇒ Arbitrary (w A) ⇒ Coarbitrary (w A) ⇒ Coarbitrary (w B) ⇒ Eq (w C)
+  ∷ ∀ w
+  . Extend w
+  ⇒ Arbitrary (w A)
+  ⇒ Coarbitrary (w A)
+  ⇒ Coarbitrary (w B)
+  ⇒ Eq (w C)
   ⇒ Proxy2 w
-  → SC eff Unit
+  → Effect Unit
 checkExtend _ = do
 
   log "Checking 'Associativity' law for Extend"

--- a/src/Test/StrongCheck/Laws/Control/Monad.purs
+++ b/src/Test/StrongCheck/Laws/Control/Monad.purs
@@ -2,21 +2,22 @@ module Test.StrongCheck.Laws.Control.Monad where
 
 import Prelude
 
-import Control.Monad.Eff.Console (log)
-
-import Type.Proxy (Proxy2)
-
-import Test.StrongCheck (SC, quickCheck')
+import Effect (Effect)
+import Effect.Console (log)
+import Test.StrongCheck (quickCheck')
 import Test.StrongCheck.Arbitrary (class Arbitrary)
 import Test.StrongCheck.Laws (A)
+import Type.Proxy (Proxy2)
 
 -- | - Left Identity: `pure x >>= f = f x`
 -- | - Right Identity: `x >>= pure = x`
 checkMonad
-  ∷ ∀ eff m
-  . Monad m ⇒ Arbitrary (m A) ⇒ Eq (m A)
+  ∷ ∀ m
+  . Monad m
+  ⇒ Arbitrary (m A)
+  ⇒ Eq (m A)
   ⇒ Proxy2 m
-  → SC eff Unit
+  → Effect Unit
 checkMonad _ = do
 
   log "Checking 'Left identity' law for Monad"

--- a/src/Test/StrongCheck/Laws/Control/MonadPlus.purs
+++ b/src/Test/StrongCheck/Laws/Control/MonadPlus.purs
@@ -3,21 +3,23 @@ module Test.StrongCheck.Laws.Control.MonadPlus where
 import Prelude
 
 import Control.Alt ((<|>))
-import Control.Monad.Eff.Console (log)
 import Control.MonadPlus (class MonadPlus)
-
-import Type.Proxy (Proxy2)
-
-import Test.StrongCheck (SC, quickCheck')
+import Effect (Effect)
+import Effect.Console (log)
+import Test.StrongCheck (quickCheck')
 import Test.StrongCheck.Arbitrary (class Arbitrary)
 import Test.StrongCheck.Laws (A, B)
+import Type.Proxy (Proxy2)
 
 -- | - Distributivity: `(x <|> y) >>= f == (x >>= f) <|> (y >>= f)`
 checkMonadPlus
-  ∷ ∀ eff m
-  . MonadPlus m ⇒ Arbitrary (m A) ⇒ Arbitrary (m B) ⇒ Eq (m B)
+  ∷ ∀ m
+  . MonadPlus m
+  ⇒ Arbitrary (m A)
+  ⇒ Arbitrary (m B)
+  ⇒ Eq (m B)
   ⇒ Proxy2 m
-  → SC eff Unit
+  → Effect Unit
 checkMonadPlus _ = do
 
   log "Checking 'Distributivity' law for MonadPlus"

--- a/src/Test/StrongCheck/Laws/Control/MonadZero.purs
+++ b/src/Test/StrongCheck/Laws/Control/MonadZero.purs
@@ -2,22 +2,24 @@ module Test.StrongCheck.Laws.Control.MonadZero where
 
 import Prelude
 
-import Control.Monad.Eff.Console (log)
 import Control.MonadZero (class MonadZero)
 import Control.Plus (empty)
-
-import Type.Proxy (Proxy2)
-
-import Test.StrongCheck (SC, quickCheck')
+import Effect (Effect)
+import Effect.Console (log)
+import Test.StrongCheck (quickCheck')
 import Test.StrongCheck.Arbitrary (class Arbitrary)
 import Test.StrongCheck.Laws (A, B)
+import Type.Proxy (Proxy2)
 
 -- | - Annihilation: `empty >>= f = empty`
 checkMonadZero
-  ∷ ∀ eff m
-  . MonadZero m ⇒ Arbitrary (m A) ⇒ Arbitrary (m B) ⇒ Eq (m B)
+  ∷ ∀ m
+  . MonadZero m
+  ⇒ Arbitrary (m A)
+  ⇒ Arbitrary (m B)
+  ⇒ Eq (m B)
   ⇒ Proxy2 m
-  → SC eff Unit
+  → Effect Unit
 checkMonadZero _ = do
 
   log "Checking 'Annihilation' law for MonadZero"

--- a/src/Test/StrongCheck/Laws/Control/Plus.purs
+++ b/src/Test/StrongCheck/Laws/Control/Plus.purs
@@ -2,24 +2,26 @@ module Test.StrongCheck.Laws.Control.Plus where
 
 import Prelude
 
-import Control.Monad.Eff.Console (log)
 import Control.Alt ((<|>))
 import Control.Plus (class Plus, empty)
-
-import Type.Proxy (Proxy2)
-
-import Test.StrongCheck (SC, quickCheck')
+import Effect (Effect)
+import Effect.Console (log)
+import Test.StrongCheck (quickCheck')
 import Test.StrongCheck.Arbitrary (class Arbitrary)
 import Test.StrongCheck.Laws (A, B)
+import Type.Proxy (Proxy2)
 
 -- | - Left identity: `empty <|> x == x`
 -- | - Right identity: `x <|> empty == x`
 -- | - Annihilation: `f <$> empty == empty`
 checkPlus
-  ∷ ∀ eff f
-  . Plus f ⇒ Arbitrary (f A) ⇒ Eq (f A) ⇒ Eq (f B)
+  ∷ ∀ f
+  . Plus f
+  ⇒ Arbitrary (f A)
+  ⇒ Eq (f A)
+  ⇒ Eq (f B)
   ⇒ Proxy2 f
-  → SC eff Unit
+  → Effect Unit
 checkPlus _ = do
 
   log "Checking 'Left identity' law for Plus"
@@ -40,4 +42,4 @@ checkPlus _ = do
   rightIdentity x = (x <|> empty) == x
 
   annihilation ∷ (A → B) → Boolean
-  annihilation f = f <$> empty == empty ∷ f B
+  annihilation f = (f <$> empty) == empty ∷ f B

--- a/src/Test/StrongCheck/Laws/Control/Semigroupoid.purs
+++ b/src/Test/StrongCheck/Laws/Control/Semigroupoid.purs
@@ -2,20 +2,23 @@ module Test.StrongCheck.Laws.Control.Semigroupoid where
 
 import Prelude
 
-import Control.Monad.Eff.Console (log)
-
-import Type.Proxy (Proxy3)
-
-import Test.StrongCheck (SC, quickCheck')
+import Effect (Effect)
+import Effect.Console (log)
+import Test.StrongCheck (quickCheck')
 import Test.StrongCheck.Arbitrary (class Arbitrary)
 import Test.StrongCheck.Laws (B, C, D, E)
+import Type.Proxy (Proxy3)
 
 -- | - Associativity: `p <<< (q <<< r) = (p <<< q) <<< r`
 checkSemigroupoid
-  ∷ ∀ eff a
-  . Semigroupoid a ⇒ Arbitrary (a B C) ⇒ Arbitrary (a C D) ⇒ Arbitrary (a D E) ⇒ Eq (a B E)
+  ∷ ∀ a
+  . Semigroupoid a
+  ⇒ Arbitrary (a B C)
+  ⇒ Arbitrary (a C D)
+  ⇒ Arbitrary (a D E)
+  ⇒ Eq (a B E)
   ⇒ Proxy3 a
-  → SC eff Unit
+  → Effect Unit
 checkSemigroupoid _ = do
 
   log "Checking 'Associativity' law for Semigroupoid"

--- a/src/Test/StrongCheck/Laws/Data/BooleanAlgebra.purs
+++ b/src/Test/StrongCheck/Laws/Data/BooleanAlgebra.purs
@@ -2,21 +2,19 @@ module Test.StrongCheck.Laws.Data.BooleanAlgebra where
 
 import Prelude
 
-import Control.Monad.Eff.Console (log)
-
 import Data.BooleanAlgebra (tt)
-
-import Type.Proxy (Proxy)
-
-import Test.StrongCheck (SC, quickCheck')
+import Effect (Effect)
+import Effect.Console (log)
+import Test.StrongCheck (quickCheck')
 import Test.StrongCheck.Arbitrary (class Arbitrary)
+import Type.Proxy (Proxy)
 
 -- | - Excluded middle: `a || not a = tt`
 checkBooleanAlgebra
-  ∷ ∀ eff a
+  ∷ ∀ a
   . Arbitrary a ⇒ BooleanAlgebra a ⇒ Eq a
   ⇒ Proxy a
-  → SC eff Unit
+  → Effect Unit
 checkBooleanAlgebra _ = do
 
   log "Checking 'Excluded middle' law for BooleanAlgebra"

--- a/src/Test/StrongCheck/Laws/Data/Bounded.purs
+++ b/src/Test/StrongCheck/Laws/Data/Bounded.purs
@@ -2,19 +2,18 @@ module Test.StrongCheck.Laws.Data.Bounded where
 
 import Prelude
 
-import Control.Monad.Eff.Console (log)
-
-import Type.Proxy (Proxy)
-
-import Test.StrongCheck (SC, quickCheck')
+import Effect (Effect)
+import Effect.Console (log)
+import Test.StrongCheck (quickCheck')
 import Test.StrongCheck.Arbitrary (class Arbitrary)
+import Type.Proxy (Proxy)
 
 -- | - Ordering: `bottom <= a <= top`
 checkBounded
-  ∷ ∀ eff a
+  ∷ ∀ a
   . Arbitrary a ⇒ Bounded a ⇒ Ord a
   ⇒ Proxy a
-  → SC eff Unit
+  → Effect Unit
 checkBounded _ = do
 
   log "Checking 'Ordering' law for Bounded"

--- a/src/Test/StrongCheck/Laws/Data/CommutativeRing.purs
+++ b/src/Test/StrongCheck/Laws/Data/CommutativeRing.purs
@@ -2,19 +2,18 @@ module Test.StrongCheck.Laws.Data.CommutativeRing where
 
 import Prelude
 
-import Control.Monad.Eff.Console (log)
-
-import Type.Proxy (Proxy)
-
-import Test.StrongCheck (SC, quickCheck')
+import Effect (Effect)
+import Effect.Console (log)
+import Test.StrongCheck (quickCheck')
 import Test.StrongCheck.Arbitrary (class Arbitrary)
+import Type.Proxy (Proxy)
 
 -- | - Commutative multiplication: `a * b = b * a`
 checkCommutativeRing
-  ∷ ∀ eff a
+  ∷ ∀ a
   . CommutativeRing a ⇒ Arbitrary a ⇒ Eq a
   ⇒ Proxy a
-  → SC eff Unit
+  → Effect Unit
 checkCommutativeRing _ = do
 
   log "Checking 'Commutative multiplication' law for CommutativeRing"

--- a/src/Test/StrongCheck/Laws/Data/Eq.purs
+++ b/src/Test/StrongCheck/Laws/Data/Eq.purs
@@ -2,22 +2,22 @@ module Test.StrongCheck.Laws.Data.Eq where
 
 import Prelude
 
-import Control.Monad.Eff.Console (log)
-
-import Type.Proxy (Proxy)
-
-import Test.StrongCheck (SC, quickCheck')
+import Effect (Effect)
+import Effect.Console (log)
+import Test.StrongCheck (quickCheck')
 import Test.StrongCheck.Arbitrary (class Arbitrary)
+import Type.Proxy (Proxy)
 
 -- | - Reflexivity: `x == x = true`
 -- | - Symmetry: `x == y = y == x`
 -- | - Transitivity: if `x == y` and `y == z` then `x == z`
 -- | - Negation: `x /= y = not (x == y)`
 checkEq
-  ∷ ∀ eff a
-  . Arbitrary a ⇒ Eq a
+  ∷ ∀ a
+  . Arbitrary a
+  ⇒ Eq a
   ⇒ Proxy a
-  → SC eff Unit
+  → Effect Unit
 checkEq _ = do
 
   log "Checking 'Reflexivity' law for Eq"

--- a/src/Test/StrongCheck/Laws/Data/EuclideanRing.purs
+++ b/src/Test/StrongCheck/Laws/Data/EuclideanRing.purs
@@ -2,21 +2,22 @@ module Test.StrongCheck.Laws.Data.EuclideanRing where
 
 import Prelude
 
-import Control.Monad.Eff.Console (log)
-
-import Type.Proxy (Proxy)
-
-import Test.StrongCheck (SC, quickCheck')
+import Effect (Effect)
+import Effect.Console (log)
+import Test.StrongCheck (quickCheck')
 import Test.StrongCheck.Arbitrary (class Arbitrary)
+import Type.Proxy (Proxy)
 
 -- | - Integral domain: `a /= 0` and `b /= 0` implies `a * b /= 0`
 -- | - Multiplicative Euclidean function: ``a = (a / b) * b + (a `mod` b)``
 -- |   where `degree a > 0` and `degree a <= degree (a * b)`
 checkEuclideanRing
-  ∷ ∀ eff a
-  . EuclideanRing a ⇒ Arbitrary a ⇒ Eq a
+  ∷ ∀ a
+  . EuclideanRing a
+  ⇒ Arbitrary a
+  ⇒ Eq a
   ⇒ Proxy a
-  → SC eff Unit
+  → Effect Unit
 checkEuclideanRing _ = do
 
   log "Checking 'Integral domain' law for EuclideanRing"

--- a/src/Test/StrongCheck/Laws/Data/Field.purs
+++ b/src/Test/StrongCheck/Laws/Data/Field.purs
@@ -2,19 +2,20 @@ module Test.StrongCheck.Laws.Data.Field where
 
 import Prelude
 
-import Control.Monad.Eff.Console (log)
-
-import Type.Proxy (Proxy)
-
-import Test.StrongCheck (SC, quickCheck')
+import Effect (Effect)
+import Effect.Console (log)
+import Test.StrongCheck (quickCheck')
 import Test.StrongCheck.Arbitrary (class Arbitrary)
+import Type.Proxy (Proxy)
 
 -- | - Non-zero multiplicative inverse: ``a `mod` b = 0` for all `a` and `b`
 checkField
-  ∷ ∀ eff a
-  . Field a ⇒ Arbitrary a ⇒ Eq a
+  ∷ ∀ a
+  . Field a
+  ⇒ Arbitrary a
+  ⇒ Eq a
   ⇒ Proxy a
-  → SC eff Unit
+  → Effect Unit
 checkField _ = do
 
   log "Checking 'Non-zero multiplicative inverse' law for Field"

--- a/src/Test/StrongCheck/Laws/Data/Functor.purs
+++ b/src/Test/StrongCheck/Laws/Data/Functor.purs
@@ -2,33 +2,32 @@ module Test.StrongCheck.Laws.Data.Functor where
 
 import Prelude
 
-import Control.Monad.Eff.Console (log)
-
-import Type.Proxy (Proxy2)
-
-import Test.StrongCheck (SC, quickCheck')
+import Effect (Effect)
+import Effect.Console (log)
+import Test.StrongCheck (quickCheck')
 import Test.StrongCheck.Arbitrary (class Arbitrary)
 import Test.StrongCheck.Laws (A, B)
+import Type.Proxy (Proxy2)
 
 -- | - Identity: `(<$>) id = id`
 -- | - Composition: `(<$>) (f <<< g) = (f <$>) <<< (g <$>)`
 checkFunctor
-  ∷ ∀ eff f
+  ∷ ∀ f
   . Functor f ⇒ Arbitrary (f A) ⇒ Eq (f A)
   ⇒ Proxy2 f
-  → SC eff Unit
+  → Effect Unit
 checkFunctor _ = do
 
   log "Checking 'Identity' law for Functor"
-  quickCheck' 1000 identity
+  quickCheck' 1000 identity'
 
   log "Checking 'Composition' law for Functor"
   quickCheck' 1000 composition
 
   where
 
-  identity ∷ f A → Boolean
-  identity f = (id <$> f) == id f
+  identity' ∷ f A → Boolean
+  identity' f = (identity <$> f) == identity f
 
   composition ∷ (B → A) → (A → B) → f A → Boolean
   composition f g x = ((<$>) (f <<< g) x) == (((f <$> _) <<< (g <$> _)) x)

--- a/src/Test/StrongCheck/Laws/Data/HeytingAlgebra.purs
+++ b/src/Test/StrongCheck/Laws/Data/HeytingAlgebra.purs
@@ -2,14 +2,12 @@ module Test.StrongCheck.Laws.Data.HeytingAlgebra where
 
 import Prelude
 
-import Control.Monad.Eff.Console (log)
-
 import Data.HeytingAlgebra (tt, ff, implies)
-
-import Type.Proxy (Proxy)
-
-import Test.StrongCheck (SC, quickCheck')
+import Effect (Effect)
+import Effect.Console (log)
+import Test.StrongCheck (quickCheck')
 import Test.StrongCheck.Arbitrary (class Arbitrary)
+import Type.Proxy (Proxy)
 
 -- | - Associativity:
 -- |   - `a || (b || c) = (a || b) || c`
@@ -34,10 +32,12 @@ import Test.StrongCheck.Arbitrary (class Arbitrary)
 -- | - Complemented:
 -- |   - ``not a = a `implies` ff``
 checkHeytingAlgebra
-  ∷ ∀ eff a
-  . Arbitrary a ⇒ HeytingAlgebra a ⇒ Eq a
+  ∷ ∀ a
+  . Arbitrary a
+  ⇒ HeytingAlgebra a
+  ⇒ Eq a
   ⇒ Proxy a
-  → SC eff Unit
+  → Effect Unit
 checkHeytingAlgebra _ = do
 
   log "Checking 'Associativity of disjunction' law for HeytingAlgebra"

--- a/src/Test/StrongCheck/Laws/Data/Monoid.purs
+++ b/src/Test/StrongCheck/Laws/Data/Monoid.purs
@@ -2,22 +2,21 @@ module Test.StrongCheck.Laws.Data.Monoid where
 
 import Prelude
 
-import Control.Monad.Eff.Console (log)
-
-import Data.Monoid (class Monoid, mempty)
-
-import Type.Proxy (Proxy)
-
-import Test.StrongCheck (SC, quickCheck')
+import Effect (Effect)
+import Effect.Console (log)
+import Test.StrongCheck (quickCheck')
 import Test.StrongCheck.Arbitrary (class Arbitrary)
+import Type.Proxy (Proxy)
 
 -- | - Left identity: `mempty <> x = x`
 -- | - Right identity: `x <> mempty = x`
 checkMonoid
-  ∷ ∀ eff m
-  . Monoid m ⇒ Arbitrary m ⇒ Eq m
+  ∷ ∀ m
+  . Monoid m
+  ⇒ Arbitrary m
+  ⇒ Eq m
   ⇒ Proxy m
-  → SC eff Unit
+  → Effect Unit
 checkMonoid _ = do
 
   log "Checking 'Left identity' law for Monoid"

--- a/src/Test/StrongCheck/Laws/Data/Ord.purs
+++ b/src/Test/StrongCheck/Laws/Data/Ord.purs
@@ -2,21 +2,21 @@ module Test.StrongCheck.Laws.Data.Ord where
 
 import Prelude
 
-import Control.Monad.Eff.Console (log)
-
-import Type.Proxy (Proxy)
-
-import Test.StrongCheck (SC, quickCheck')
+import Effect (Effect)
+import Effect.Console (log)
+import Test.StrongCheck (quickCheck')
 import Test.StrongCheck.Arbitrary (class Arbitrary)
+import Type.Proxy (Proxy)
 
 -- | - Reflexivity: `a <= a`
 -- | - Antisymmetry: if `a <= b` and `b <= a` then `a = b`
 -- | - Transitivity: if `a <= b` and `b <= c` then `a <= c`
 checkOrd
-  ∷ ∀ eff a
-  . Arbitrary a ⇒ Ord a
+  ∷ ∀ a
+  . Arbitrary a
+  ⇒ Ord a
   ⇒ Proxy a
-  → SC eff Unit
+  → Effect Unit
 checkOrd _ = do
 
   log "Checking 'Reflexivity' law for Ord"

--- a/src/Test/StrongCheck/Laws/Data/Ring.purs
+++ b/src/Test/StrongCheck/Laws/Data/Ring.purs
@@ -2,19 +2,20 @@ module Test.StrongCheck.Laws.Data.Ring where
 
 import Prelude
 
-import Control.Monad.Eff.Console (log)
-
-import Type.Proxy (Proxy)
-
-import Test.StrongCheck (SC, quickCheck')
+import Effect (Effect)
+import Effect.Console (log)
+import Test.StrongCheck (quickCheck')
 import Test.StrongCheck.Arbitrary (class Arbitrary)
+import Type.Proxy (Proxy)
 
 -- | - Additive inverse: `a - a = a + (-a) = (-a) + a = zero`
 checkRing
-  ∷ ∀ eff a
-  . Ring a ⇒ Arbitrary a ⇒ Eq a
+  ∷ ∀ a
+  . Ring a
+  ⇒ Arbitrary a
+  ⇒ Eq a
   ⇒ Proxy a
-  → SC eff Unit
+  → Effect Unit
 checkRing _ = do
 
   log "Checking 'Additive inverse' law for Ring"

--- a/src/Test/StrongCheck/Laws/Data/Semigroup.purs
+++ b/src/Test/StrongCheck/Laws/Data/Semigroup.purs
@@ -2,19 +2,20 @@ module Test.StrongCheck.Laws.Data.Semigroup where
 
 import Prelude
 
-import Control.Monad.Eff.Console (log)
-
-import Type.Proxy (Proxy)
-
-import Test.StrongCheck (SC, quickCheck')
+import Effect (Effect)
+import Effect.Console (log)
+import Test.StrongCheck (quickCheck')
 import Test.StrongCheck.Arbitrary (class Arbitrary)
+import Type.Proxy (Proxy)
 
 -- | - Associativity: `(x <> y) <> z = x <> (y <> z)`
 checkSemigroup
-  ∷ ∀ eff s
-  . Semigroup s ⇒ Arbitrary s ⇒ Eq s
+  ∷ ∀ s
+  . Semigroup s
+  ⇒ Arbitrary s
+  ⇒ Eq s
   ⇒ Proxy s
-  → SC eff Unit
+  → Effect Unit
 checkSemigroup _ = do
 
   log "Checking 'Associativity' law for Semigroup"

--- a/src/Test/StrongCheck/Laws/Data/Semiring.purs
+++ b/src/Test/StrongCheck/Laws/Data/Semiring.purs
@@ -2,12 +2,11 @@ module Test.StrongCheck.Laws.Data.Semiring where
 
 import Prelude
 
-import Control.Monad.Eff.Console (log)
-
-import Type.Proxy (Proxy)
-
-import Test.StrongCheck (SC, quickCheck')
+import Effect (Effect)
+import Effect.Console (log)
+import Test.StrongCheck (quickCheck')
 import Test.StrongCheck.Arbitrary (class Arbitrary)
+import Type.Proxy (Proxy)
 
 -- | - Commutative monoid under addition:
 -- |   - Associativity: `(a + b) + c = a + (b + c)`
@@ -21,10 +20,12 @@ import Test.StrongCheck.Arbitrary (class Arbitrary)
 -- |   - Right distributivity: `(a + b) * c = (a * c) + (b * c)`
 -- | - Annihiliation: `zero * a = a * zero = zero`
 checkSemiring
-  ∷ ∀ eff a
-  . Semiring a ⇒ Arbitrary a ⇒ Eq a
+  ∷ ∀ a
+  . Semiring a
+  ⇒ Arbitrary a
+  ⇒ Eq a
   ⇒ Proxy a
-  → SC eff Unit
+  → Effect Unit
 checkSemiring _ = do
 
   log "Checking 'Associativity' law for Semiring addition"

--- a/test/Test/Data/Either.purs
+++ b/test/Test/Data/Either.purs
@@ -3,14 +3,13 @@ module Test.Data.Either where
 import Prelude
 
 import Data.Either (Either)
-
-import Test.StrongCheck.Laws (SC, A, B, C, checkLaws)
+import Effect (Effect)
+import Test.StrongCheck.Laws (A, B, C, checkLaws)
 import Test.StrongCheck.Laws.Control as Control
 import Test.StrongCheck.Laws.Data as Data
-
 import Type.Proxy (Proxy(..), Proxy2(..))
 
-checkEither ∷ ∀ eff. SC eff Unit
+checkEither ∷ Effect Unit
 checkEither = checkLaws "Either" do
   Data.checkEq prxEither
   Data.checkOrd prxEither

--- a/test/Test/Data/Identity.purs
+++ b/test/Test/Data/Identity.purs
@@ -3,14 +3,13 @@ module Test.Data.Identity where
 import Prelude
 
 import Data.Identity (Identity)
-
-import Test.StrongCheck.Laws (SC, A, checkLaws)
+import Effect (Effect)
+import Test.StrongCheck.Laws (A, checkLaws)
 import Test.StrongCheck.Laws.Control as Control
 import Test.StrongCheck.Laws.Data as Data
-
 import Type.Proxy (Proxy(..), Proxy2(..))
 
-checkIdentity ∷ ∀ eff. SC eff Unit
+checkIdentity ∷ Effect Unit
 checkIdentity = checkLaws "Identity" do
   Data.checkEq prxIdentity
   Data.checkOrd prxIdentity

--- a/test/Test/Data/List.purs
+++ b/test/Test/Data/List.purs
@@ -3,14 +3,13 @@ module Test.Data.List where
 import Prelude
 
 import Data.List (List)
-
-import Test.StrongCheck.Laws (SC, A, checkLaws)
+import Effect (Effect)
+import Test.StrongCheck.Laws (A, checkLaws)
 import Test.StrongCheck.Laws.Control as Control
 import Test.StrongCheck.Laws.Data as Data
-
 import Type.Proxy (Proxy(..), Proxy2(..))
 
-checkList ∷ ∀ eff. SC eff Unit
+checkList ∷ Effect Unit
 checkList = checkLaws "List" do
   Data.checkEq prxList
   Data.checkOrd prxList

--- a/test/Test/Data/Maybe.purs
+++ b/test/Test/Data/Maybe.purs
@@ -3,14 +3,13 @@ module Test.Data.Maybe where
 import Prelude
 
 import Data.Maybe (Maybe)
-
-import Test.StrongCheck.Laws (SC, A, checkLaws)
+import Effect (Effect)
+import Test.StrongCheck.Laws (A, checkLaws)
 import Test.StrongCheck.Laws.Control as Control
 import Test.StrongCheck.Laws.Data as Data
-
 import Type.Proxy (Proxy(..), Proxy2(..))
 
-checkMaybe ∷ ∀ eff. SC eff Unit
+checkMaybe ∷ Effect Unit
 checkMaybe = checkLaws "Maybe" do
   Data.checkEq prxMaybe
   Data.checkOrd prxMaybe

--- a/test/Test/Data/Ordering.purs
+++ b/test/Test/Data/Ordering.purs
@@ -2,12 +2,12 @@ module Test.Data.Ordering where
 
 import Prelude
 
-import Test.StrongCheck.Laws (SC, checkLaws)
+import Effect (Effect)
+import Test.StrongCheck.Laws (checkLaws)
 import Test.StrongCheck.Laws.Data as Data
-
 import Type.Proxy (Proxy(..))
 
-checkOrdering ∷ ∀ eff. SC eff Unit
+checkOrdering ∷ Effect Unit
 checkOrdering = checkLaws "Ordering" do
   Data.checkEq prxOrdering
   Data.checkOrd prxOrdering

--- a/test/Test/Data/Tuple.purs
+++ b/test/Test/Data/Tuple.purs
@@ -3,14 +3,13 @@ module Test.Data.Tuple where
 import Prelude
 
 import Data.Tuple (Tuple)
-
-import Test.StrongCheck.Laws (SC, A, B, C, checkLaws)
+import Effect (Effect)
+import Test.StrongCheck.Laws (A, B, C, checkLaws)
 import Test.StrongCheck.Laws.Control as Control
 import Test.StrongCheck.Laws.Data as Data
-
 import Type.Proxy (Proxy(..), Proxy2(..), Proxy3(..))
 
-checkTuple ∷ ∀ eff. SC eff Unit
+checkTuple ∷ Effect Unit
 checkTuple = checkLaws "Tuple" do
   Data.checkEq prxTuple
   Data.checkOrd prxTuple

--- a/test/Test/Data/Unit.purs
+++ b/test/Test/Data/Unit.purs
@@ -2,12 +2,12 @@ module Test.Data.Unit where
 
 import Prelude
 
-import Test.StrongCheck.Laws (SC, checkLaws)
+import Effect (Effect)
+import Test.StrongCheck.Laws (checkLaws)
 import Test.StrongCheck.Laws.Data as Data
-
 import Type.Proxy (Proxy(..))
 
-checkUnit ∷ ∀ eff. SC eff Unit
+checkUnit ∷ Effect Unit
 checkUnit = checkLaws "Unit" do
   Data.checkEq prxUnit
   Data.checkOrd prxUnit

--- a/test/Test/Main.purs
+++ b/test/Test/Main.purs
@@ -2,7 +2,7 @@ module Test.Main where
 
 import Prelude
 
-import Test.StrongCheck (SC)
+import Effect (Effect)
 import Test.Data.Either (checkEither)
 import Test.Data.Identity (checkIdentity)
 import Test.Data.List (checkList)
@@ -16,7 +16,7 @@ import Test.Prim.Int (checkInt)
 import Test.Prim.Number (checkNumber)
 import Test.Prim.String (checkString)
 
-main ∷ SC () Unit
+main ∷ Effect Unit
 main = do
   checkArray
   checkBoolean

--- a/test/Test/Prim/Array.purs
+++ b/test/Test/Prim/Array.purs
@@ -2,13 +2,13 @@ module Test.Prim.Array where
 
 import Prelude
 
-import Test.StrongCheck.Laws (SC, A, checkLaws)
+import Effect (Effect)
+import Test.StrongCheck.Laws (A, checkLaws)
 import Test.StrongCheck.Laws.Control as Control
 import Test.StrongCheck.Laws.Data as Data
-
 import Type.Proxy (Proxy(..), Proxy2(..))
 
-checkArray ∷ ∀ eff. SC eff Unit
+checkArray ∷ Effect Unit
 checkArray = checkLaws "Array" do
   Data.checkEq prxArray
   Data.checkOrd prxArray

--- a/test/Test/Prim/Boolean.purs
+++ b/test/Test/Prim/Boolean.purs
@@ -2,12 +2,12 @@ module Test.Prim.Boolean where
 
 import Prelude
 
-import Test.StrongCheck.Laws (SC, checkLaws)
+import Effect (Effect)
+import Test.StrongCheck.Laws (checkLaws)
 import Test.StrongCheck.Laws.Data as Data
-
 import Type.Proxy (Proxy(..))
 
-checkBoolean ∷ ∀ eff. SC eff Unit
+checkBoolean ∷ Effect Unit
 checkBoolean = checkLaws "Boolean" do
   Data.checkEq prxBoolean
   Data.checkOrd prxBoolean

--- a/test/Test/Prim/Int.purs
+++ b/test/Test/Prim/Int.purs
@@ -2,14 +2,14 @@ module Test.Prim.Int where
 
 import Prelude
 
+import Effect (Effect)
 import Test.StrongCheck.Arbitrary (class Arbitrary, class Coarbitrary)
 import Test.StrongCheck.Gen (chooseInt)
-import Test.StrongCheck.Laws (SC, checkLaws)
+import Test.StrongCheck.Laws (checkLaws)
 import Test.StrongCheck.Laws.Data as Data
-
 import Type.Proxy (Proxy(..))
 
-checkInt ∷ ∀ eff. SC eff Unit
+checkInt ∷ Effect Unit
 checkInt = checkLaws "Int" do
   Data.checkEq prxInt
   Data.checkOrd prxInt

--- a/test/Test/Prim/Number.purs
+++ b/test/Test/Prim/Number.purs
@@ -2,20 +2,19 @@ module Test.Prim.Number where
 
 import Prelude
 
+import Effect (Effect)
 import Test.StrongCheck.Data.ApproxNumber (ApproxNumber)
-import Test.StrongCheck.Laws (SC, checkLaws)
+import Test.StrongCheck.Laws (checkLaws)
 import Test.StrongCheck.Laws.Data as Data
-
 import Type.Proxy (Proxy(..))
 
-checkNumber ∷ ∀ eff. SC eff Unit
+checkNumber ∷ Effect Unit
 checkNumber = checkLaws "Number" do
   Data.checkEq prxNumber
   Data.checkOrd prxNumber
   Data.checkSemiring prxNumber
   Data.checkEuclideanRing prxNumber
   Data.checkRing prxNumber
-  Data.checkField prxNumber
   Data.checkCommutativeRing prxNumber
   where
   prxNumber = Proxy ∷ Proxy ApproxNumber

--- a/test/Test/Prim/String.purs
+++ b/test/Test/Prim/String.purs
@@ -2,12 +2,12 @@ module Test.Prim.String where
 
 import Prelude
 
-import Test.StrongCheck.Laws (SC, checkLaws)
+import Effect (Effect)
+import Test.StrongCheck.Laws (checkLaws)
 import Test.StrongCheck.Laws.Data as Data
-
 import Type.Proxy (Proxy(..))
 
-checkString ∷ ∀ eff. SC eff Unit
+checkString ∷ Effect Unit
 checkString = checkLaws "String" do
   Data.checkEq prxString
   Data.checkOrd prxString


### PR DESCRIPTION
This PR updates `purescript-strongcheck-laws` similarly to the updates to `purescript-quickcheck-laws` and makes it compatible with 0.12 and therefore usable to update packages like Rationals.

Verified the library builds and tests pass. It is almost 100% functionally equivalent to the prior version. The only change was that I removed `Data.checkField prxNumber` from the tests for `Prim.Number` because there is no available instance anymore.

Cheers,
Thomas