### PR TITLE
Update laws to include DivisionRing, update tests for Number.

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -20,7 +20,7 @@
     "package.json"
   ],
   "dependencies": {
-    "purescript-strongcheck": "^4.0.0",
+    "purescript-strongcheck": "^4.1.0",
     "purescript-proxy": "^3.0.0"
   }
 }

--- a/src/Test/StrongCheck/Laws/Data.purs
+++ b/src/Test/StrongCheck/Laws/Data.purs
@@ -3,6 +3,7 @@ module Test.StrongCheck.Laws.Data (module Exports) where
 import Test.StrongCheck.Laws.Data.BooleanAlgebra (checkBooleanAlgebra) as Exports
 import Test.StrongCheck.Laws.Data.Bounded (checkBounded) as Exports
 import Test.StrongCheck.Laws.Data.CommutativeRing (checkCommutativeRing) as Exports
+import Test.StrongCheck.Laws.Data.DivisionRing (checkDivisionRing) as Exports
 import Test.StrongCheck.Laws.Data.Eq (checkEq) as Exports
 import Test.StrongCheck.Laws.Data.EuclideanRing (checkEuclideanRing) as Exports
 import Test.StrongCheck.Laws.Data.Field (checkField) as Exports

--- a/src/Test/StrongCheck/Laws/Data/DivisionRing.purs
+++ b/src/Test/StrongCheck/Laws/Data/DivisionRing.purs
@@ -31,7 +31,8 @@ checkDivisionRing _ = do
   nonZero = (one :: Eq a => a) /= zero
 
   inverse ∷ DivisionRing a => a → Boolean
-  inverse a =
-    recip a * a == a * recip a
-    && recip a * a == one
-    && a * recip a == one
+  inverse a
+    | a == zero = true
+    | (recip a * a == a * recip a) && (recip a * a == one) && (a * recip a == one) = true
+    | otherwise = false
+

--- a/src/Test/StrongCheck/Laws/Data/DivisionRing.purs
+++ b/src/Test/StrongCheck/Laws/Data/DivisionRing.purs
@@ -1,0 +1,37 @@
+module Test.StrongCheck.Laws.Data.DivisionRing where
+
+import Prelude
+
+import Effect (Effect)
+import Effect.Console (log)
+import Test.StrongCheck (quickCheck')
+import Test.StrongCheck.Arbitrary (class Arbitrary)
+import Type.Proxy (Proxy)
+
+-- | Non-zero ring: one /= zero
+-- | Non-zero multiplicative inverse: recip a * a = a * recip a = one for all non-zero a
+checkDivisionRing
+  ∷ ∀ a
+  . DivisionRing a
+  ⇒ Arbitrary a
+  ⇒ Eq a
+  ⇒ Proxy a
+  → Effect Unit
+checkDivisionRing _ = do
+
+  log "Checking 'Non-zero ring' law for DivisionRing"
+  quickCheck' 1000 nonZero
+
+  log "Checking 'Non-zero multiplicative inverse' law for DivisionRing"
+  quickCheck' 1000 inverse
+
+  where
+
+  nonZero ∷ Boolean
+  nonZero = (one :: Eq a => a) /= zero
+
+  inverse ∷ DivisionRing a => a → Boolean
+  inverse a =
+    recip a * a == a * recip a
+    && recip a * a == one
+    && a * recip a == one

--- a/test/Test/Prim/Number.purs
+++ b/test/Test/Prim/Number.purs
@@ -14,6 +14,7 @@ checkNumber = checkLaws "Number" do
   Data.checkOrd prxNumber
   Data.checkSemiring prxNumber
   Data.checkEuclideanRing prxNumber
+  Data.checkDivisionRing prxNumber
   Data.checkRing prxNumber
   Data.checkCommutativeRing prxNumber
   where


### PR DESCRIPTION
Sorry to be sending over a new update so soon, but `purescript-rationals` now uses a `DivisionRing` instance and I wanted to make sure there were tests for those laws available. I've added the laws here. However, this relies on the `purescript-strongcheck` repository to provide the right instance for `ApproxNumber`. These two pull requests work together.

https://github.com/purescript-contrib/purescript-strongcheck/pull/53

Division laws were taken from Pursuit:
https://pursuit.purescript.org/packages/purescript-prelude/4.0.1/docs/Data.DivisionRing#t:DivisionRing