### PR TITLE
Deprecate package on Pursuit

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -4,7 +4,7 @@
   "description": "Law tests for core classes",
   "keywords": [
     "purescript",
-    "purescript-deprecated"
+    "pursuit-deprecated"
   ],
   "license": "MIT",
   "repository": {

--- a/bower.json
+++ b/bower.json
@@ -9,7 +9,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git://github.com/garyb/purescript-strongcheck-laws.git"
+    "url": "https://github.com/garyb/purescript-strongcheck-laws.git"
   },
   "ignore": [
     "**/.*",

--- a/bower.json
+++ b/bower.json
@@ -3,7 +3,8 @@
   "homepage": "https://github.com/garyb/purescript-strongcheck-laws",
   "description": "Law tests for core classes",
   "keywords": [
-    "purescript"
+    "purescript",
+    "purescript-deprecated"
   ],
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
This PR makes the changes required to [deprecate this package on Pursuit](https://pursuit.purescript.org/help/authors#package-deprecation), since it depends on [`purescript-strongcheck`](https://github.com/purescript-deprecated/purescript-strongcheck), which is also deprecated.

A new package version would need to be published after this PR is merged.
